### PR TITLE
Chore/#1 프로젝트 기본 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.3'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2' // asciidoctor convert 사용
 }
 
 group = 'com.personal'
@@ -12,6 +13,7 @@ java {
 }
 
 configurations {
+    asciidoctorExt // html 자동 변경 사용 설정
     compileOnly {
         extendsFrom annotationProcessor
     }
@@ -21,20 +23,60 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    set('snippetsDir', file("build/generated-snippets")) // snippetsDir 위치 설정
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    //p6spy 설치
+    // 'p6spy' 설치
     implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+    // 'RestDocs' 설치 (.adocs를 html로 자동 변화)
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+tasks.named('asciidoctor') {
+    inputs.dir snippetsDir
+    dependsOn test
+    configurations 'asciidoctorExt' // html 자동 변경 사용
+    baseDirFollowsSourceFile() // .adoc 파일에서 다른.adoc 파일을 include하여 사용할 때 경로를 동일하게 baseDir로 설정
+}
+
+asciidoctor.doFirst {
+    delete file('src/main/resources/static/docs') //실행 전 이전 html 삭제
+}
+
+// build/docs/asciidoc 에 생성된 html 문서를 src/main/resources/static/docs 에 복사해온다.
+task createDocument(type: Copy) {
+    dependsOn asciidoctor // asciidoctor 후 실행
+
+    from file("build/docs/asciidoc")
+    into file("src/main/resources/static")
+}
+
+//jar의 static/docs에 문서 복사
+bootJar {
+    dependsOn createDocument
+
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
+}
+
+//빌드전 createDocument 실행
+build {
+    dependsOn createDocument
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    //p6spy 설치
+    implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0"
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/com/personal/smartbudgetcraft/global/config/p6spy/P6SpyFormatter.java
+++ b/src/main/java/com/personal/smartbudgetcraft/global/config/p6spy/P6SpyFormatter.java
@@ -1,0 +1,42 @@
+package com.personal.smartbudgetcraft.global.config.p6spy;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import jakarta.annotation.PostConstruct;
+import java.util.Locale;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * p6Spy 설정 : 쿼리 로그의 가독성 높임
+ */
+@Configuration
+public class P6SpyFormatter implements MessageFormattingStrategy {
+
+  @PostConstruct
+  public void setLogMessageFormat() {
+    P6SpyOptions.getActiveInstance().setLogMessageFormat(this.getClass().getName());
+  }
+
+  @Override
+  public String formatMessage(int connectionId, String now, long elapsed, String category,
+      String prepared, String sql, String url) {
+    sql = formatSql(category, sql);
+    return String.format("[%s] | %d ms | %s", category, elapsed, formatSql(category, sql));
+  }
+
+  private String formatSql(String category, String sql) {
+    if (sql != null && !sql.trim().isEmpty() && Category.STATEMENT.getName().equals(category)) {
+      String trimmedSQL = sql.trim().toLowerCase(Locale.ROOT);
+      if (trimmedSQL.startsWith("create") || trimmedSQL.startsWith("alter")
+          || trimmedSQL.startsWith("comment")) {
+        sql = FormatStyle.DDL.getFormatter().format(sql);
+      } else {
+        sql = FormatStyle.BASIC.getFormatter().format(sql);
+      }
+      return sql;
+    }
+    return sql;
+  }
+}

--- a/src/main/java/com/personal/smartbudgetcraft/global/dto/response/ApiResDto.java
+++ b/src/main/java/com/personal/smartbudgetcraft/global/dto/response/ApiResDto.java
@@ -1,4 +1,4 @@
-package com.personal.smartbudgetcraft.global.util.format.response;
+package com.personal.smartbudgetcraft.global.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,7 +8,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor
-public class ResponseApi {
+public class ApiResDto {
 
   private static final String STATUS_SUCCESS = "success";
   private static final String STATUS_FAIL = "fail";
@@ -27,8 +27,8 @@ public class ResponseApi {
    * @param data 데이터 내용
    * @return 성공 APIResponse
    */
-  public static ResponseApi toSuccessForm(Object data) {
-    return new ResponseApi(STATUS_SUCCESS, null, data);
+  public static ApiResDto toSuccessForm(Object data) {
+    return new ApiResDto(STATUS_SUCCESS, null, data);
   }
 
   /**
@@ -37,8 +37,8 @@ public class ResponseApi {
    * @param message 실패 메시지
    * @return 실패 APIResponse
    */
-  public static ResponseApi toFailForm(String message) {
-    return new ResponseApi(STATUS_FAIL, message, null);
+  public static ApiResDto toFailForm(String message) {
+    return new ApiResDto(STATUS_FAIL, message, null);
   }
 
   /**
@@ -47,7 +47,7 @@ public class ResponseApi {
    * @param message 에러 메시지
    * @return 에러 APIResponse
    */
-  public static ResponseApi toErrorForm(String message) {
-    return new ResponseApi(STATUS_ERROR, message, null);
+  public static ApiResDto toErrorForm(String message) {
+    return new ApiResDto(STATUS_ERROR, message, null);
   }
 }

--- a/src/main/java/com/personal/smartbudgetcraft/global/util/format/response/ResponseApi.java
+++ b/src/main/java/com/personal/smartbudgetcraft/global/util/format/response/ResponseApi.java
@@ -1,0 +1,53 @@
+package com.personal.smartbudgetcraft.global.util.format.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Response JSON 포맷팅 형식
+ */
+@Getter
+@AllArgsConstructor
+public class ResponseApi {
+
+  private static final String STATUS_SUCCESS = "success";
+  private static final String STATUS_FAIL = "fail";
+  private static final String STATUS_ERROR = "error";
+
+  // 상태 (성공,실패,에러)
+  private String status;
+  // 실패/에러 메시지 (성공일시 null)
+  private String message;
+  // 데이터 (실패/에러일 때 null)
+  private Object data;
+
+  /**
+   * 성공했을 때, 반환하는 APIResponse
+   *
+   * @param data 데이터 내용
+   * @return 성공 APIResponse
+   */
+  public static ResponseApi toSuccessForm(Object data) {
+    return new ResponseApi(STATUS_SUCCESS, null, data);
+  }
+
+  /**
+   * 실패했을 때, 반환하는 APIResponse
+   *
+   * @param message 실패 메시지
+   * @return 실패 APIResponse
+   */
+  public static ResponseApi toFailForm(String message) {
+    return new ResponseApi(STATUS_FAIL, message, null);
+  }
+
+  /**
+   * 예외처리가 됐을 때, 반환하는 APIResponse
+   *
+   * @param message 에러 메시지
+   * @return 에러 APIResponse
+   */
+  public static ResponseApi toErrorForm(String message) {
+    return new ResponseApi(STATUS_ERROR, message, null);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+
+#p6spy
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+server:
+  port: 8080
+  servlet:
+    context-path: /
+    encoding:
+      charset: utf-8
+    session:
+      timeout: 60
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/smartBudgetCraft?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: root
+    password: root
+  jpa:
+    hibernate:
+      ddl-auto: create

--- a/src/test/java/com/personal/smartbudgetcraft/config/restdocs/AbstractRestDocsTests.java
+++ b/src/test/java/com/personal/smartbudgetcraft/config/restdocs/AbstractRestDocsTests.java
@@ -1,0 +1,42 @@
+package com.personal.smartbudgetcraft.config.restdocs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+/**
+ * mockMvc를 사용할 때, 자동으로 rest docs 작성하게 한다.
+ */
+@Import(RestDocsConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class AbstractRestDocsTests {
+
+  @Autowired
+  protected RestDocumentationResultHandler restDocs;
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @BeforeEach
+  void setUp(
+      final WebApplicationContext context,
+      final RestDocumentationContextProvider restDocumentation) {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .apply(documentationConfiguration(restDocumentation))
+        .alwaysDo(MockMvcResultHandlers.print())
+        .alwaysDo(restDocs)
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))
+        .build();
+  }
+}

--- a/src/test/java/com/personal/smartbudgetcraft/config/restdocs/RestDocsConfiguration.java
+++ b/src/test/java/com/personal/smartbudgetcraft/config/restdocs/RestDocsConfiguration.java
@@ -1,0 +1,23 @@
+package com.personal.smartbudgetcraft.config.restdocs;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+/**
+ * rest docs의 가독성을 높인다.
+ */
+@TestConfiguration
+public class RestDocsConfiguration {
+
+  @Bean
+  public RestDocumentationResultHandler write() {
+    return MockMvcRestDocumentation.document(
+        "{class-name}/{method-name}", // identifier
+        Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+        Preprocessors.preprocessResponse(Preprocessors.prettyPrint())
+    );
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #1 

## 📝 Description

- 사용할 포트를 8080으로 설정 하였고, DB 스키마 명은 `smartbudgetcraft`입니다. 

- `P6Spy`로 JAP 실제 쿼리 로그를 보기좋게 설정하였습니다.
  - 추후 배포때, 로그는 `디버그`일 때만 보이도록 합니다.

- 컨트롤러 계층 테스트 때, 추상화 클래스인 `AbstractRestDocsTests`를 상속받아 `mockMvc`를 사용해야 Rest Docs가 적용됩니다.

- 공통 API의 Response Dto인  `ApiResDto`로 정하였습니다. 
  - 추후 static 생성자를 사용하여, `successForm`, `failForm`, `errorForm`로 변환시켜 ResponseEntity에 넣습니다.
  
## ⭐️ Review


