### PR TITLE
Feature/#3 공통 예외 처리 구현

### DIFF
--- a/src/main/java/com/personal/smartbudgetcraft/global/error/BusinessException.java
+++ b/src/main/java/com/personal/smartbudgetcraft/global/error/BusinessException.java
@@ -1,0 +1,35 @@
+package com.personal.smartbudgetcraft.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 로직에서 예외를 발생시킬 때 사용하는 언체크 예외
+ */
+@Getter
+public class BusinessException extends RuntimeException {
+
+  //오류 발생 부분의 값. 명확하게 없으면 Null.
+  private final String invalidValue;
+  //오류 필드명.
+  private final String fieldName;
+  //오류 상태 코드.
+  private final HttpStatus httpStatus;
+  //오류 메시지
+  private final String message;
+
+  /**
+   * 비지니스 에러를 ErroCode Enum으로 생성
+   *
+   * @param invalidValue 오류 발생 부분의 값
+   * @param fieldName    오류 필드 명
+   * @param errorCode    오류 상태코드와 메시지가 담긴 Enum
+   */
+  public BusinessException(Object invalidValue, String fieldName, ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.invalidValue = invalidValue != null ? invalidValue.toString() : null;
+    this.fieldName = fieldName;
+    this.httpStatus = errorCode.getHttpStatus();
+    this.message = errorCode.getMessage();
+  }
+}

--- a/src/main/java/com/personal/smartbudgetcraft/global/error/ErrorCode.java
+++ b/src/main/java/com/personal/smartbudgetcraft/global/error/ErrorCode.java
@@ -1,0 +1,23 @@
+package com.personal.smartbudgetcraft.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 오류 메시지와 상태를 쉽게 추가하기 위한 Enum
+ */
+@Getter
+public enum ErrorCode {
+  ;
+
+  //오류 메시지
+  private final String message;
+  //오류 상태코드
+  private final HttpStatus httpStatus;
+
+  ErrorCode(String message, HttpStatus httpStatus) {
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+
+}

--- a/src/main/java/com/personal/smartbudgetcraft/global/error/ExceptionAdvice.java
+++ b/src/main/java/com/personal/smartbudgetcraft/global/error/ExceptionAdvice.java
@@ -1,0 +1,76 @@
+package com.personal.smartbudgetcraft.global.error;
+
+import com.personal.smartbudgetcraft.global.dto.response.ApiResDto;
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * 공통 예외 처리
+ */
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+  /**
+   * `BindException` 오류가 발생할 때, 핸들링
+   *
+   * @param e BindException 오류
+   * @return 오류 내용을 담은 ResponseEntity
+   */
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ApiResDto> bindException(BindException e) {
+    // 오류로 원하는 문자열 포맷팅.
+    String errorMessage = getErrorMessage(e);
+
+    return ResponseEntity.badRequest()
+        .body(ApiResDto.toErrorForm(errorMessage));
+  }
+
+  /**
+   * BindingException의 bindingResult 분석 후, 오류 메시지 생성
+   *
+   * @param e BindException
+   * @return 포멧팅된 오류 메시지
+   */
+  private static String getErrorMessage(BindException e) {
+    BindingResult bindingResult = e.getBindingResult();
+
+    return bindingResult.getFieldErrors().stream()
+        .map(fieldError ->
+            getErrorMessage(
+                String.valueOf(fieldError.getRejectedValue()), // 값
+                fieldError.getField(), // 필드명
+                fieldError.getDefaultMessage() // 오류 메시지
+            )
+        )
+        .collect(Collectors.joining(", "));
+  }
+
+  /**
+   * `BusinessException` 오류가 발생할 때, 핸들링
+   *
+   * @param e BusinessException 오류
+   * @return 오류 내용을 담은 ResponseEntity
+   */
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ApiResDto> businessException(BusinessException e) {
+    // 오류로 원하는 문자열 포맷팅.
+    String errorMessage = getErrorMessage(e.getInvalidValue(), e.getFieldName(), e.getMessage());
+
+    return ResponseEntity.status(e.getHttpStatus())
+        .body(ApiResDto.toErrorForm(errorMessage));
+  }
+
+
+  /**
+   * 메시지 포멧팅
+   * "[{오류 값}] {필드명} : {오류 메시지}"
+   */
+  private static String getErrorMessage(String invalidValue, String errorField,
+      String errorMessage) {
+    return String.format("[%s] %s: %s", invalidValue, errorField, errorMessage);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #3 

## 📝 Description

다음과 같이 전역 예외 처리를 구현하였습니다.

`ErrorCode`로 원하는 예외 메시지 및 상태 코드를 Enum으로 쉽게 관리하여, 추가 및 수정에 용이하게 구현하였습니다.
`BusinessException`로 로직상 예외를 발생시켜야할 때, 사용하는 언체크 예외를 구현하였습니다.

`ExceptionAdvice`는 `@RestControllerAdvice`로 예외가 발생할 때, 위의 클래스를 이용하여, 
`"[{오류값}] : {오류필드명}: {오류메시지}"` 형식인 메시지를 포함한 `APIResponse`의 에러 폼과 원하는 상태코드를 포함된 `ResponseEntity`를 반환합니다.
```JSON
{
  "status" : "error",
  "message" : "[{오류값}] {오류필드}: {오류메시지}.",
  "data" : null
}
```

이로써, 예외가 발생하면, 원하는 메시지와 상태 코드로 보낼 수 있습니다.

추후 예외를 발생 시킬려면
`ErrorCode`에 상태코드 및 오류 메시지를 `도메인_상태코드명`으로 만든 , 값,필드,ErrorCode로 예외를 발생시킵니다.
```java
ex) new BusinessException(recruitId, "recruitId", ErrorCode.RECRUIT_NOT_FOUND)
```

## ⭐️ Review
